### PR TITLE
Support XDG Base Directory Specification

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,9 @@ When it exists, you would run that command below.
 
 ### Custom keybinds/behavior
 
-Create an rc file in ~/.ahuburc with contents such as this (`cp conf/default-rc ~/.ahuburc`):
+Ahubu looks for configuration in `$HOME/.ahuburc` and `$XDG_CONFIG_HOME/ahubu/ahuburc`,
+which overrides the defaults. To get started customizing, copy the default from
+`conf/default-rc` in this project to either of those locations and modify accordingly.
 
 You can bind any of the following to your key presses:
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -290,7 +290,7 @@ partial match on the URL or title to filter your results to that match.
 
 <p>
 To jump to a quickmark (like a bookmark, but much better), press 'go'
-followed by te quickmark defined in your ~/.ahuburc file (you do have
+followed by te quickmark defined in your ~/.ahuburc or $XDG_CONFIG_HOME/ahubu/ahuburc file (you do have
 one of those right?)
 </p>
 
@@ -362,7 +362,7 @@ list of DOM class identifiers to exclude from rendering.
 <h4 id="org9388148"><span class="section-number-4">1.2.2</span> Quickmarks and Keybinds</h4>
 <div class="outline-text-4" id="text-1-2-2">
 <p>
-Create an rc file in ~/.ahuburc with contents such as this:
+Create an rc file in ~/.ahuburc (or $XDG_CONFIG_HOME/ahubu/ahuburc) with contents such as this:
 </p>
 
 <div class="org-src-container">

--- a/docs/index.org
+++ b/docs/index.org
@@ -24,8 +24,8 @@ Press 'b' to view a list of your open buffers (tabs) and type some
 partial match on the URL or title to filter your results to that match.
 
 To jump to a quickmark (like a bookmark, but much better), press 'go'
-followed by te quickmark defined in your ~/.ahuburc file (you do have
-one of those right?)
+followed by te quickmark defined in your ~/.ahuburc or $XDG_CONFIG_HOME/ahubu/ahuburc
+file (you do have one of those right?)
 
 So, if your file looked like this:
 
@@ -61,7 +61,7 @@ Look at the project's conf/dom-class-ignores.txt file to add your own
 list of DOM class identifiers to exclude from rendering.
 
 *** Quickmarks and Keybinds
-Create an rc file in ~/.ahuburc with contents such as this:
+Create an rc file in ~/.ahuburc (or $XDG_CONFIG_HOME/ahubu/ahuburc) with contents such as this:
 
 #+BEGIN_SRC sh
  cp conf/default-rc ~/.ahuburc

--- a/src/ahubu/lib.clj
+++ b/src/ahubu/lib.clj
@@ -504,14 +504,15 @@
   (omnibar-load-url url))
 
 (defn get-rc-file-raw []
-  (let [defaults (read-string (slurp "conf/default-rc"))]
-    (try
-      (conj
-       defaults
-       (read-string (slurp (format "%s/.ahuburc" (System/getProperty "user.home")))))
-      (catch Throwable t
-        (println t)
-        defaults))))
+  (let [defaults (read-string (slurp "conf/default-rc"))
+        home-rc (format "%s/.ahuburc" (System/getProperty "user.home"))
+        xdg-rc (format "%s/ahubu/ahuburc" (System/getenv "XDG_CONFIG_HOME"))]
+    (conj
+      defaults
+      (if (.exists (clojure.java.io/file home-rc))
+        (read-string (slurp home-rc)))
+      (if (.exists (clojure.java.io/file xdg-rc))
+        (read-string (slurp xdg-rc))))))
 
 (defn get-rc-file []
   (let [rc (get-rc-file-raw)


### PR DESCRIPTION
I love apps which support the [XDG Base Directory Specification](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html) because they make it much easier to version control and manage configuration (and cache, and data, etc.) in an organized fashion.

When conj'ing customizations over the defaults, look for
$XDG_CONFIG_HOME/ahubu/ahuburc in addition to ~/.ahuburc for users who
prefer to keep their home directory tidy.